### PR TITLE
Added an option to sort by outdated

### DIFF
--- a/DependencyChecker.Test/DependencyChecker.Test.csproj
+++ b/DependencyChecker.Test/DependencyChecker.Test.csproj
@@ -50,6 +50,9 @@
     <Content Include="TestProjects\CombineProjects\Different\net462\packages.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="TestProjects\Sorted\DependencyCheckerSorted.csproj">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DependencyChecker\DependencyChecker.csproj" />

--- a/DependencyChecker.Test/SortingTest.cs
+++ b/DependencyChecker.Test/SortingTest.cs
@@ -1,0 +1,53 @@
+﻿using System.IO;
+using System.Linq;
+
+using DependencyChecker.Model;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DependencyChecker.Test;
+
+[TestClass]
+public class SortingTest
+{
+    [TestMethod]
+    [DataRow(true, DisplayName = "WithSorting")]
+    [DataRow(false, DisplayName = "WithoutSorting")]
+    public void SortingOptionTest(bool withSorting)
+    {
+        var option = new Options()
+        {
+            SearchPath = "TestProjects/Sorted",
+            SearchRec = true,
+            CombineProjects = true,
+            CreateReport = true,
+            ReportPath = "ReportResults/CombineDifferentReport.html",
+            SortByOutdated = withSorting
+        };
+
+        var runner = new Runner();
+        runner.Run(option);
+
+        var projects = runner.CodeProjects;
+
+        Assert.AreEqual(1, projects.Count);
+
+        var project = projects.First();
+        Assert.IsTrue(project.HasPackages);
+        Assert.AreEqual(3, project.PackageStatuses.Count);
+        
+        Assert.AreEqual("Dependency Report", project.Name);
+        Assert.IsNull(project.NuGetFile);
+
+        if (withSorting)
+        {
+            Assert.AreNotEqual(project.PackageStatuses.First().Id, "EnterpriseLibrary.Common");
+        }
+        else
+        {
+            Assert.AreEqual(project.PackageStatuses.First().Id, "EnterpriseLibrary.Common");
+        }
+        // Check Report File
+        Assert.IsTrue(File.Exists(option.ReportPath));
+    }
+}

--- a/DependencyChecker.Test/TestProjects/Sorted/DependencyCheckerSorted.csproj
+++ b/DependencyChecker.Test/TestProjects/Sorted/DependencyCheckerSorted.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <RootNamespace>DependencyChecker.Tests</RootNamespace>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="EnterpriseLibrary.Common" Version="6.0.1304" />
+    <PackageReference Include="Newtonsoft.Json" Version="2.4.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+  </ItemGroup>
+
+</Project>

--- a/DependencyChecker/Model/Options.cs
+++ b/DependencyChecker/Model/Options.cs
@@ -45,6 +45,9 @@ namespace DependencyChecker.Model
 
         [Option("azure-artifacts-uri", Required = false, HelpText = "An additional source like Azure Artifacts")]
         public string AzureArtifactsFeedUri{ get; set; }
+        
+        [Option("sort-by-outdated", Required = false, HelpText = "Sort by outdated packages, bringing them first in the list.")]
+        public bool SortByOutdated { get; set; }
 
         #endregion
     }

--- a/DependencyChecker/Model/PackageStatus.cs
+++ b/DependencyChecker/Model/PackageStatus.cs
@@ -5,24 +5,14 @@ namespace DependencyChecker.Model
 {
     public class PackageStatus
     {
-        #region Properties
-
         public string CurrentVersion { get; set; }
-
         public string Id { get; set; }
-
         public string InstalledVersion { get; set; }
-
         public bool NoLocalVersion { get; set; }
-
         public bool NotFound { get; set; }
-
         public bool Outdated { get; set; }
-
         public Uri ProjectUrl { get; set; }
         public string DefinedInFile { get; set; }
-
-        #endregion
     }
 
     public class IdAndInstalledVersionComparer : IEqualityComparer<PackageStatus>

--- a/buildtask/index.ts
+++ b/buildtask/index.ts
@@ -21,8 +21,8 @@ async function run() {
         var nuGetFile = tl.getPathInput("customNuGetfile", false);
         var useArtifacts = tl.getBoolInput("useArtifacts", true);
         var artifactsFeeds = tl.getInput("artifactsFeeds", false);
+        var sortByOutdated = tl.getBoolInput("sortByOutdated", false);
         var collectionUri = process.env.SYSTEM_COLLECTIONURI;
-
 
         let toolPath = __dirname + "\\..\\bin\\DependencyChecker.exe";
 
@@ -59,6 +59,9 @@ async function run() {
             artifactsUri = artifactsUri.replace("visualstudio.com", "pkgs.visualstudio.com");
             arg.push("--azure-artifacts-uri", artifactsUri);
         }
+
+        if (sortByOutdated)
+            arg.push("--sort-by-outdated");
 
         let tool: trm.ToolRunner = tl.tool(toolPath).arg(arg);
         let result: number = await tool.exec();

--- a/buildtask/task.json
+++ b/buildtask/task.json
@@ -171,6 +171,16 @@
             "helpMarkDown": "Location and name where to save report.",
             "groupName": "report",
             "visibleRule": "createReport = true"
+        },
+        {
+            "name": "sortByOutdated",
+            "type": "boolean",
+            "label": "Outdated First",
+            "defaultValue": false,
+            "required": false,
+            "helpMarkDown": "Put the outdated packages at the top of the report.",
+            "groupName": "report",
+            "visibleRule": "createReport = true"
         }
     ],
     "dataSourceBindings": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -3,7 +3,7 @@
     "id": "dependency-checker",
     "name": "NuGet Dependency Checker",
     "description": "Tool for checking NuGet dependencies.",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "publisher": "chwebdude",
     "public": true,
     "tags": [


### PR DESCRIPTION
Added a new option `--sort-by-outdated` which causes all outdated packages to be pushed to the top of the report.