### PR TITLE
NET8 upgrade, updated NuGet packages and Node version

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/DependencyChecker.Test/DependencyChecker.Test.csproj
+++ b/DependencyChecker.Test/DependencyChecker.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
@@ -63,22 +63,21 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NuGet.Common" Version="6.5.0" />
-    <PackageReference Include="NuGet.Configuration" Version="6.5.0" />
-    <PackageReference Include="NuGet.Frameworks" Version="6.5.0" />
-    <PackageReference Include="NuGet.Packaging" Version="6.5.0" />
-    <PackageReference Include="NuGet.Packaging.Core" Version="6.5.0" />
+    <PackageReference Include="NuGet.Common" Version="6.12.1" />
+    <PackageReference Include="NuGet.Configuration" Version="6.12.1" />
+    <PackageReference Include="NuGet.Frameworks" Version="6.12.1" />
+    <PackageReference Include="NuGet.Packaging" Version="6.12.1" />
     <PackageReference Include="NuGet.Packaging.Core.Types" Version="4.2.0" />
     <PackageReference Include="NuGet.Protocol.Core.Types" Version="4.2.0" />
     <PackageReference Include="NuGet.Protocol.Core.v3" Version="4.2.0" />
-    <PackageReference Include="NuGet.Versioning" Version="6.5.0" />
+    <PackageReference Include="NuGet.Versioning" Version="6.12.1" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="7.0.1" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="9.0.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/DependencyChecker.Test/TestProjects/CombineProjects/Okay/ReportReference.html
+++ b/DependencyChecker.Test/TestProjects/CombineProjects/Okay/ReportReference.html
@@ -42,7 +42,7 @@
                 <a href="https://nunit.org/" target="_blank">NUnit</a>
             </th>
             <td>3.12.0</td>
-            <td>3.13.3</td>
+            <td>4.2.2</td>
             <td>Outdated</td>
         </tr>
 

--- a/DependencyChecker.sln
+++ b/DependencyChecker.sln
@@ -7,6 +7,15 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DependencyChecker", "Depend
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DependencyChecker.Test", "DependencyChecker.Test\DependencyChecker.Test.csproj", "{DCE61F91-67F9-49BF-A0ED-AB00D0FEB7BF}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{13304ABD-B776-409F-AA7B-A3A9F363FE90}"
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+		build.bat = build.bat
+		LICENSE = LICENSE
+		Readme.md = Readme.md
+		vss-extension.json = vss-extension.json
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/DependencyChecker.sln
+++ b/DependencyChecker.sln
@@ -14,6 +14,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		LICENSE = LICENSE
 		Readme.md = Readme.md
 		vss-extension.json = vss-extension.json
+		.github\workflows\dotnet.yml = .github\workflows\dotnet.yml
 	EndProjectSection
 EndProject
 Global

--- a/DependencyChecker/DependencyChecker.csproj
+++ b/DependencyChecker/DependencyChecker.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <LangVersion>default</LangVersion>
@@ -45,23 +45,22 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.VisualStudio.Services.NuGet.CredentialProvider" Version="0.37.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NuGet.Common" Version="6.5.0" />
-    <PackageReference Include="NuGet.Configuration" Version="6.5.0" />
-    <PackageReference Include="NuGet.Frameworks" Version="6.5.0" />
-    <PackageReference Include="NuGet.Packaging" Version="6.5.0" />
-    <PackageReference Include="NuGet.Packaging.Core" Version="6.5.0" />
+    <PackageReference Include="NuGet.Common" Version="6.12.1" />
+    <PackageReference Include="NuGet.Configuration" Version="6.12.1" />
+    <PackageReference Include="NuGet.Frameworks" Version="6.12.1" />
+    <PackageReference Include="NuGet.Packaging" Version="6.12.1" />
     <PackageReference Include="NuGet.Packaging.Core.Types" Version="4.2.0" />
     <PackageReference Include="NuGet.Protocol.Core.Types" Version="4.2.0" />
     <PackageReference Include="NuGet.Protocol.Core.v3" Version="4.2.0" />
-    <PackageReference Include="NuGet.Versioning" Version="6.5.0" />
+    <PackageReference Include="NuGet.Versioning" Version="6.12.1" />
     <PackageReference Include="Stubble.Core" Version="1.10.8" />
-    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="9.0.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="7.0.1" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="9.0.0" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/buildtask/task.json
+++ b/buildtask/task.json
@@ -9,7 +9,7 @@
     "author": "chwebdude",
     "version": {
         "Major": 1,
-        "Minor": 3,
+        "Minor": 4,
         "Patch": 0
     },
     "instanceNameFormat": "Check Dependencies",

--- a/buildtask/task.json
+++ b/buildtask/task.json
@@ -193,7 +193,10 @@
         }
     ],
     "execution": {
-        "Node": {
+        "Node16": {
+            "target": "dist/index.js"
+        },
+        "Node20_1": {
             "target": "dist/index.js"
         }
     }

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -3,7 +3,7 @@
     "id": "dependency-checker",
     "name": "NuGet Dependency Checker",
     "description": "Tool for checking NuGet dependencies.",
-    "version": "1.3.1",
+    "version": "1.4.0",
     "publisher": "chwebdude",
     "public": true,
     "tags": [


### PR DESCRIPTION
- **Upgraded to NET8.**
- Updated all NuGet packages to their respective latest versions.
- Updated tasks.json to use Node20_1 as default, falling back to Node16 in case version 20.1 is not present.